### PR TITLE
fix: move check for file option to correct spot in open_library

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -1830,13 +1830,13 @@ class QtDriver(DriverMixin, QObject):
 
     def open_library(self, path: Path) -> None:
         """Open a TagStudio library."""
-        message = Translations["splash.opening_library"].format(library_path=str(path))
-        self.main_window.landing_widget.set_status_label(message)
-        self.main_window.statusbar.showMessage(message, 3)
         filepath_option: str = str(
             self.settings.value(SettingItems.SHOW_FILEPATH, defaultValue="show full path", type=str)
         )
         library_dir_display = path if filepath_option == "show full path" else path.name
+        message = Translations["splash.opening_library"].format(library_path=library_dir_display)
+        self.main_window.landing_widget.set_status_label(message)
+        self.main_window.statusbar.showMessage(message, 3)
         self.main_window.repaint()
 
         if self.lib.library_dir:


### PR DESCRIPTION
### Summary

<!--
^^^ Summarize the changes done and why they were done above.

By submitting this pull request, you certify that you have read the
[CONTRIBUTING.md](https://github.com/TagStudioDev/TagStudio/blob/main/CONTRIBUTING.md).

IMPORTANT FOR FEATURES: Please verify that a feature request or some other form
of communication with maintainers was already conducted in terms of approving.

Thank you for your eagerness to contribute!
-->

### Tasks Completed

<!-- No requirements, just context for reviewers. -->

-   Platforms Tested:
    -   [ ] Windows x86
    -   [ ] Windows ARM
    -   [ ] macOS x86
    -   [ ] macOS ARM
    -   [ ] Linux x86
    -   [ ] Linux ARM
    <!-- If an unspecified platform was tested, please add it here -->
-   Tested For:
    -   [ ] Basic functionality
    -   [ ] PyInstaller executable <!-- Not necessarily required, but appreciated! -->
    <!-- If other important criteria was tested for, please add it here -->
